### PR TITLE
feat: Ability to @\everyone in announcements

### DIFF
--- a/src/extensions/announce/__init__.py
+++ b/src/extensions/announce/__init__.py
@@ -6,6 +6,7 @@ from typing import Never, final, override
 import discord
 from discord import InputTextStyle, Interaction, MediaGalleryItem
 from discord.ui import (
+    Checkbox,
     DesignerModal,
     DesignerView,
     FileUpload,
@@ -34,6 +35,9 @@ class AnnounceModal(DesignerModal):
         self.role_select = RoleSelect(min_values=0, max_values=10, required=False)
         self.add_item(Label(label=self.translations.roles_to_mention, item=self.role_select))
 
+        self.ping_everyone_checkbox = Checkbox(default=False)
+        self.add_item(Label(label=self.translations.ping_everyone, item=self.ping_everyone_checkbox))
+
         self.title_input = TextInput(required=True, style=InputTextStyle.short, max_length=256)
         self.add_item(Label(label=self.translations.announcement_title, item=self.title_input))
 
@@ -56,10 +60,12 @@ class AnnounceModal(DesignerModal):
 
         components: list[ViewItem[DesignerView]] = []
 
-        if self.role_select.values:
-            components.append(
-                TextDisplay[DesignerView, Never](" ".join(role.mention for role in self.role_select.values))
-            )
+        mentions: list[str] = [role.mention for role in self.role_select.values or []]
+        if self.ping_everyone_checkbox.value:
+            mentions.append("@everyone")
+
+        if mentions:
+            components.append(TextDisplay[DesignerView, Never](" ".join(mentions)))
 
         if self.title_input.value:
             components.append(TextDisplay[DesignerView, Never](f"# {self.title_input.value}"))
@@ -82,7 +88,13 @@ class AnnounceModal(DesignerModal):
         components.append(
             TextDisplay[DesignerView, Never](self.translations.announcement_signature.format(author=interaction.user))
         )
-        await interaction.channel.send(view=DesignerView(*components), files=[image] if image is not None else [])  # pyright: ignore[reportAttributeAccessIssue]
+        await interaction.channel.send(  # pyright: ignore[reportAttributeAccessIssue]
+            view=DesignerView(*components),
+            files=[image] if image is not None else [],
+            allowed_mentions=discord.AllowedMentions(
+                everyone=self.ping_everyone_checkbox.value or False, roles=True, users=True
+            ),
+        )
 
 
 @final

--- a/src/extensions/announce/translations.yml
+++ b/src/extensions/announce/translations.yml
@@ -18,6 +18,9 @@ commands:
       roles_to_mention:
         en-US: "Roles to mention"
         fr: "Roles à mentionner"
+      ping_everyone:
+        en-US: "Ping everyone"
+        fr: "Mentionner tout le monde"
       announcement_title:
         en-US: "Announcement title"
         fr: "Titre de l'annonce"

--- a/src/extensions/help/pages/announce.yml
+++ b/src/extensions/help/pages/announce.yml
@@ -25,6 +25,8 @@ pages:
     quick_tips:
       - en-US: "You can mention up to 10 roles directly from the role selector."
         fr: "Tu peux mentionner jusqu'a 10 roles directement via le selecteur de roles."
+      - en-US: "Check the ping everyone box to mention @everyone in the announcement."
+        fr: "Coche la case mentionner tout le monde pour mentionner @everyone dans l'annonce."
       - en-US: "Keep titles short and move details to content for better readability."
         fr: "Garde un titre court et mets les details dans le contenu pour une meilleure lisibilite."
     examples:


### PR DESCRIPTION
## Description

Possibilité de ping everyone dans les annonces.

## Type de changement

<!-- Cochez les cases appropriées avec [x] -->

- [ ] Nouvelle extension
- [x] Amélioration d'une extension existante
- [ ] Correction de bug
- [ ] Amélioration de documentation
- [ ] Autre (précisez) :

## Extension concernée

<!-- Indiquez le nom de l'extension modifiée ou créée, le cas échéant -->

Extension : `src/extensions/announce`

- [ ] Ce changement ne concerne pas une extension (documentation, etc...)

## Fonctionnalités ajoutées/modifiées

<!-- Listez les nouvelles commandes, fonctionnalités ou changements -->

- CHeckbox in announcement modal

## Tests effectués

<!-- Décrivez comment vous avez testé votre contribution. Il n'est pas nécessaire de cocher TOUTES les cases -->

- [ ] Testé localement sur un serveur Discord de développement
- [ ] Testé toutes les commandes ajoutées/modifiées
- [ ] Vérifié que les messages d'erreur s'affichent correctement
- [ ] Testé les permissions Discord si applicable
- [x] Exécuté `pdm run lint` sans erreurs
- [x] Exécuté `pdm run format`
- [x] Typecheck

### Captures d'écran (si applicable)

<!-- Ajoutez des captures d'écran montrant la fonctionnalité en action -->

## Checklist obligatoire

<!-- IMPORTANT : Toutes ces cases doivent être cochées avant la soumission -->

- [x] **Je suis capable d'expliquer comment fonctionne mon code**
- [x] **Mon code respecte les standards du projet** (Ruff, conventions de nommage)
- [x] **Je suis ouvert aux retours et prêt à apporter des modifications**
- [x] **Ma contribution n'est pas entièrement générée par une IA** (ou j'ai tout relu et compris)

## Notes supplémentaires

<!-- Toute information supplémentaire utile pour les reviewers -->
